### PR TITLE
Feature/board/list all post

### DIFF
--- a/src/main/java/demo/userboard/controller/BoardController.java
+++ b/src/main/java/demo/userboard/controller/BoardController.java
@@ -22,7 +22,7 @@ public class BoardController {
     private final BoardService boardService;
 
     @GetMapping("/boards")
-    public CommonResponse<List<AllBoardListResponseDto>> allBoardList(@RequestParam(defaultValue = "0") int page,
+    public CommonResponse<List<AllBoardListResponseDto>> allBoardList(@RequestParam(defaultValue = "1") int page,
                                                                       @RequestParam(defaultValue = "10") int size) {
         return ApiResponseUtil.success(boardService.findAllBoard(page, size));
     }

--- a/src/main/java/demo/userboard/controller/BoardController.java
+++ b/src/main/java/demo/userboard/controller/BoardController.java
@@ -21,7 +21,7 @@ public class BoardController {
 
     private final BoardService boardService;
 
-    @GetMapping("/board")
+    @GetMapping("/boards")
     public CommonResponse<List<AllBoardListResponseDto>> allBoardList() {
         return ApiResponseUtil.success(boardService.findAllBoard());
     }

--- a/src/main/java/demo/userboard/controller/BoardController.java
+++ b/src/main/java/demo/userboard/controller/BoardController.java
@@ -23,7 +23,7 @@ public class BoardController {
     @GetMapping("/boards")
     public CommonResponse<PageInfoResponseDto<AllBoardListResponseDto>> allBoardList(@RequestParam(defaultValue = "1") int page,
                                                                                      @RequestParam(defaultValue = "10") int size) {
-        return ApiResponseUtil.success(boardService.findAllBoard(page, size));
+        return ApiResponseUtil.success(boardService.boardListPaged(page, size));
     }
 
     @GetMapping("/board/{boardId}")

--- a/src/main/java/demo/userboard/controller/BoardController.java
+++ b/src/main/java/demo/userboard/controller/BoardController.java
@@ -5,6 +5,7 @@ import demo.userboard.dto.request.BoardUpdateRequestDto;
 import demo.userboard.dto.request.PostRequestDto;
 import demo.userboard.dto.response.AllBoardListResponseDto;
 import demo.userboard.dto.response.BoardDetailViewResponseDto;
+import demo.userboard.dto.response.PageInfoResponseDto;
 import demo.userboard.global.annotation.SessionAuth;
 import demo.userboard.global.common.auth.SessionLoginInfo;
 import demo.userboard.global.common.response.CommonResponse;
@@ -13,8 +14,6 @@ import demo.userboard.service.BoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 public class BoardController {
@@ -22,8 +21,8 @@ public class BoardController {
     private final BoardService boardService;
 
     @GetMapping("/boards")
-    public CommonResponse<List<AllBoardListResponseDto>> allBoardList(@RequestParam(defaultValue = "1") int page,
-                                                                      @RequestParam(defaultValue = "10") int size) {
+    public CommonResponse<PageInfoResponseDto<AllBoardListResponseDto>> allBoardList(@RequestParam(defaultValue = "1") int page,
+                                                                                     @RequestParam(defaultValue = "10") int size) {
         return ApiResponseUtil.success(boardService.findAllBoard(page, size));
     }
 

--- a/src/main/java/demo/userboard/controller/BoardController.java
+++ b/src/main/java/demo/userboard/controller/BoardController.java
@@ -3,6 +3,7 @@ package demo.userboard.controller;
 import demo.userboard.dto.request.BoardDeleteRequestDto;
 import demo.userboard.dto.request.BoardUpdateRequestDto;
 import demo.userboard.dto.request.PostRequestDto;
+import demo.userboard.dto.response.AllBoardListResponseDto;
 import demo.userboard.dto.response.BoardDetailViewResponseDto;
 import demo.userboard.global.annotation.SessionAuth;
 import demo.userboard.global.common.auth.SessionLoginInfo;
@@ -12,11 +13,18 @@ import demo.userboard.service.BoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 public class BoardController {
 
     private final BoardService boardService;
+
+    @GetMapping("/board")
+    public CommonResponse<List<AllBoardListResponseDto>> allBoardList() {
+        return ApiResponseUtil.success(boardService.findAllBoard());
+    }
 
     @GetMapping("/board/{boardId}")
     public CommonResponse<BoardDetailViewResponseDto> detailView(@PathVariable("boardId") Long boardId) {

--- a/src/main/java/demo/userboard/controller/BoardController.java
+++ b/src/main/java/demo/userboard/controller/BoardController.java
@@ -22,8 +22,9 @@ public class BoardController {
     private final BoardService boardService;
 
     @GetMapping("/boards")
-    public CommonResponse<List<AllBoardListResponseDto>> allBoardList() {
-        return ApiResponseUtil.success(boardService.findAllBoard());
+    public CommonResponse<List<AllBoardListResponseDto>> allBoardList(@RequestParam(defaultValue = "0") int page,
+                                                                      @RequestParam(defaultValue = "10") int size) {
+        return ApiResponseUtil.success(boardService.findAllBoard(page, size));
     }
 
     @GetMapping("/board/{boardId}")

--- a/src/main/java/demo/userboard/dto/response/AllBoardListResponseDto.java
+++ b/src/main/java/demo/userboard/dto/response/AllBoardListResponseDto.java
@@ -1,0 +1,19 @@
+package demo.userboard.dto.response;
+
+import demo.userboard.domain.Board;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AllBoardListResponseDto {
+    private Long boardId;
+    private String title;
+    private String writer;
+
+    public static AllBoardListResponseDto from(Board board) {
+        return new AllBoardListResponseDto(board.getId(), board.getTitle(), board.getUser().getNickname());
+    }
+}

--- a/src/main/java/demo/userboard/dto/response/PageInfoResponseDto.java
+++ b/src/main/java/demo/userboard/dto/response/PageInfoResponseDto.java
@@ -1,0 +1,15 @@
+package demo.userboard.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PageInfoResponseDto<T> {
+    private List<T> content;
+    private PagingResponseDto paging;
+}

--- a/src/main/java/demo/userboard/dto/response/PageInfoResponseDto.java
+++ b/src/main/java/demo/userboard/dto/response/PageInfoResponseDto.java
@@ -12,4 +12,15 @@ import java.util.List;
 public class PageInfoResponseDto<T> {
     private List<T> content;
     private PagingResponseDto paging;
+
+    public static <T> PageInfoResponseDto<T> of(int page, int size, List<T> contents) {
+        List<T> subList = contents.subList(0, Math.min(contents.size(), size));
+
+        PagingResponseDto pagingResponseDto = new PagingResponseDto(
+                page,
+                size,
+                contents.size() > size,
+                subList.size());
+        return new PageInfoResponseDto<>(subList, pagingResponseDto);
+    }
 }

--- a/src/main/java/demo/userboard/dto/response/PagingResponseDto.java
+++ b/src/main/java/demo/userboard/dto/response/PagingResponseDto.java
@@ -1,0 +1,15 @@
+package demo.userboard.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PagingResponseDto {
+    private int pageNumber;
+    private int pageSize;
+    private boolean hasNext;
+    private int numberOfElements;
+}

--- a/src/main/java/demo/userboard/repository/BoardRepository.java
+++ b/src/main/java/demo/userboard/repository/BoardRepository.java
@@ -14,4 +14,6 @@ public interface BoardRepository {
     void delete(Long boardId);
 
     List<Board> findAll(int page, int size);
+
+    Long countAllBoards();
 }

--- a/src/main/java/demo/userboard/repository/BoardRepository.java
+++ b/src/main/java/demo/userboard/repository/BoardRepository.java
@@ -14,6 +14,4 @@ public interface BoardRepository {
     void delete(Long boardId);
 
     List<Board> getPagedBoard(int page, int size);
-
-    Long countAllBoards();
 }

--- a/src/main/java/demo/userboard/repository/BoardRepository.java
+++ b/src/main/java/demo/userboard/repository/BoardRepository.java
@@ -2,6 +2,7 @@ package demo.userboard.repository;
 
 import demo.userboard.domain.Board;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BoardRepository {
@@ -11,4 +12,6 @@ public interface BoardRepository {
     Optional<Board> findBoardById(Long boardId);
 
     void delete(Long boardId);
+
+    List<Board> findAll();
 }

--- a/src/main/java/demo/userboard/repository/BoardRepository.java
+++ b/src/main/java/demo/userboard/repository/BoardRepository.java
@@ -13,7 +13,7 @@ public interface BoardRepository {
 
     void delete(Long boardId);
 
-    List<Board> findAll(int page, int size);
+    List<Board> getPagedBoard(int page, int size);
 
     Long countAllBoards();
 }

--- a/src/main/java/demo/userboard/repository/BoardRepository.java
+++ b/src/main/java/demo/userboard/repository/BoardRepository.java
@@ -13,5 +13,5 @@ public interface BoardRepository {
 
     void delete(Long boardId);
 
-    List<Board> findAll();
+    List<Board> findAll(int page, int size);
 }

--- a/src/main/java/demo/userboard/repository/JpaMemoryBoardRepository.java
+++ b/src/main/java/demo/userboard/repository/JpaMemoryBoardRepository.java
@@ -36,10 +36,10 @@ public class JpaMemoryBoardRepository implements BoardRepository {
     }
 
     @Override
-    public List<Board> findAll() {
+    public List<Board> findAll(int page, int size) {
         List<Board> resultList = em.createQuery("select b from Board b where b.status = true order by b.id desc", Board.class)
-                .setFirstResult(0)
-                .setMaxResults(10)
+                .setFirstResult((page - 1) * size)
+                .setMaxResults(size)
                 .getResultList();
         return resultList;
     }

--- a/src/main/java/demo/userboard/repository/JpaMemoryBoardRepository.java
+++ b/src/main/java/demo/userboard/repository/JpaMemoryBoardRepository.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -32,5 +33,14 @@ public class JpaMemoryBoardRepository implements BoardRepository {
     public void delete(Long boardId) {
         Board board = em.find(Board.class, boardId);
         board.changeStatus(false);
+    }
+
+    @Override
+    public List<Board> findAll() {
+        List<Board> resultList = em.createQuery("select b from Board b where b.status = true order by b.id desc", Board.class)
+                .setFirstResult(0)
+                .setMaxResults(10)
+                .getResultList();
+        return resultList;
     }
 }

--- a/src/main/java/demo/userboard/repository/JpaMemoryBoardRepository.java
+++ b/src/main/java/demo/userboard/repository/JpaMemoryBoardRepository.java
@@ -43,4 +43,10 @@ public class JpaMemoryBoardRepository implements BoardRepository {
                 .getResultList();
         return resultList;
     }
+
+    @Override
+    public Long countAllBoards() {
+        return em.createQuery("select count(b) from Board b where b.status = true", Long.class)
+                .getSingleResult();
+    }
 }

--- a/src/main/java/demo/userboard/repository/JpaMemoryBoardRepository.java
+++ b/src/main/java/demo/userboard/repository/JpaMemoryBoardRepository.java
@@ -43,10 +43,4 @@ public class JpaMemoryBoardRepository implements BoardRepository {
                 .getResultList();
         return resultList;
     }
-
-    @Override
-    public Long countAllBoards() {
-        return em.createQuery("select count(b) from Board b where b.status = true", Long.class)
-                .getSingleResult();
-    }
 }

--- a/src/main/java/demo/userboard/repository/JpaMemoryBoardRepository.java
+++ b/src/main/java/demo/userboard/repository/JpaMemoryBoardRepository.java
@@ -36,10 +36,10 @@ public class JpaMemoryBoardRepository implements BoardRepository {
     }
 
     @Override
-    public List<Board> findAll(int page, int size) {
+    public List<Board> getPagedBoard(int page, int size) {
         List<Board> resultList = em.createQuery("select b from Board b where b.status = true order by b.id desc", Board.class)
                 .setFirstResult((page - 1) * size)
-                .setMaxResults(size)
+                .setMaxResults(size + 1)
                 .getResultList();
         return resultList;
     }

--- a/src/main/java/demo/userboard/service/BoardService.java
+++ b/src/main/java/demo/userboard/service/BoardService.java
@@ -18,5 +18,5 @@ public interface BoardService {
 
     Long boardDelete(BoardDeleteRequestDto deleteRequestDto);
 
-    List<AllBoardListResponseDto> findAllBoard();
+    List<AllBoardListResponseDto> findAllBoard(int page, int size);
 }

--- a/src/main/java/demo/userboard/service/BoardService.java
+++ b/src/main/java/demo/userboard/service/BoardService.java
@@ -17,5 +17,5 @@ public interface BoardService {
 
     Long boardDelete(BoardDeleteRequestDto deleteRequestDto);
 
-    PageInfoResponseDto<AllBoardListResponseDto> findAllBoard(int page, int size);
+    PageInfoResponseDto<AllBoardListResponseDto> boardListPaged(int page, int size);
 }

--- a/src/main/java/demo/userboard/service/BoardService.java
+++ b/src/main/java/demo/userboard/service/BoardService.java
@@ -3,7 +3,10 @@ package demo.userboard.service;
 import demo.userboard.dto.request.BoardDeleteRequestDto;
 import demo.userboard.dto.request.BoardUpdateRequestDto;
 import demo.userboard.dto.request.PostRequestDto;
+import demo.userboard.dto.response.AllBoardListResponseDto;
 import demo.userboard.dto.response.BoardDetailViewResponseDto;
+
+import java.util.List;
 
 public interface BoardService {
 
@@ -14,4 +17,6 @@ public interface BoardService {
     Long boardUpdate(BoardUpdateRequestDto updateRequestDto);
 
     Long boardDelete(BoardDeleteRequestDto deleteRequestDto);
+
+    List<AllBoardListResponseDto> findAllBoard();
 }

--- a/src/main/java/demo/userboard/service/BoardService.java
+++ b/src/main/java/demo/userboard/service/BoardService.java
@@ -5,8 +5,7 @@ import demo.userboard.dto.request.BoardUpdateRequestDto;
 import demo.userboard.dto.request.PostRequestDto;
 import demo.userboard.dto.response.AllBoardListResponseDto;
 import demo.userboard.dto.response.BoardDetailViewResponseDto;
-
-import java.util.List;
+import demo.userboard.dto.response.PageInfoResponseDto;
 
 public interface BoardService {
 
@@ -18,5 +17,5 @@ public interface BoardService {
 
     Long boardDelete(BoardDeleteRequestDto deleteRequestDto);
 
-    List<AllBoardListResponseDto> findAllBoard(int page, int size);
+    PageInfoResponseDto<AllBoardListResponseDto> findAllBoard(int page, int size);
 }

--- a/src/main/java/demo/userboard/service/BoardServiceImpl.java
+++ b/src/main/java/demo/userboard/service/BoardServiceImpl.java
@@ -8,7 +8,6 @@ import demo.userboard.dto.request.PostRequestDto;
 import demo.userboard.dto.response.AllBoardListResponseDto;
 import demo.userboard.dto.response.BoardDetailViewResponseDto;
 import demo.userboard.dto.response.PageInfoResponseDto;
-import demo.userboard.dto.response.PagingResponseDto;
 import demo.userboard.global.common.response.CustomErrorCode;
 import demo.userboard.global.core.exception.CustomException;
 import demo.userboard.repository.BoardRepository;
@@ -81,18 +80,13 @@ public class BoardServiceImpl implements BoardService {
     }
 
     @Override
-    public PageInfoResponseDto<AllBoardListResponseDto> findAllBoard(int page, int size) {
-        List<Board> boardList = boardRepository.findAll(page, size);
-        List<AllBoardListResponseDto> list = boardList
+    public PageInfoResponseDto<AllBoardListResponseDto> boardListPaged(int page, int size) {
+        List<AllBoardListResponseDto> boardList = boardRepository.getPagedBoard(page, size)
                 .stream()
                 .map(AllBoardListResponseDto::from)
                 .toList();
 
-        Long totalBoard = boardRepository.countAllBoards();
-        int numberOfElements = list.size();
-        boolean hasNext = page * size < totalBoard;
-        PagingResponseDto pagingResponseDto = new PagingResponseDto(page, size, hasNext, numberOfElements);
-        return new PageInfoResponseDto<>(list, pagingResponseDto);
+        return PageInfoResponseDto.of(page, size, boardList);
     }
 
     private Board findUserBoard(Long boardId, Long userId) {

--- a/src/main/java/demo/userboard/service/BoardServiceImpl.java
+++ b/src/main/java/demo/userboard/service/BoardServiceImpl.java
@@ -5,6 +5,7 @@ import demo.userboard.domain.User;
 import demo.userboard.dto.request.BoardDeleteRequestDto;
 import demo.userboard.dto.request.BoardUpdateRequestDto;
 import demo.userboard.dto.request.PostRequestDto;
+import demo.userboard.dto.response.AllBoardListResponseDto;
 import demo.userboard.dto.response.BoardDetailViewResponseDto;
 import demo.userboard.global.common.response.CustomErrorCode;
 import demo.userboard.global.core.exception.CustomException;
@@ -14,6 +15,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Transactional(readOnly = true)
 @Service
@@ -73,6 +77,15 @@ public class BoardServiceImpl implements BoardService {
         boardRepository.delete(board.getId());
 
         return deleteRequestDto.getBoardId();
+    }
+
+    @Override
+    public List<AllBoardListResponseDto> findAllBoard() {
+        List<Board> boardList = boardRepository.findAll();
+        return boardList
+                .stream()
+                .map(AllBoardListResponseDto::from)
+                .collect(Collectors.toList());
     }
 
     private Board findUserBoard(Long boardId, Long userId) {

--- a/src/main/java/demo/userboard/service/BoardServiceImpl.java
+++ b/src/main/java/demo/userboard/service/BoardServiceImpl.java
@@ -17,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Transactional(readOnly = true)
 @Service
@@ -85,7 +84,7 @@ public class BoardServiceImpl implements BoardService {
         return boardList
                 .stream()
                 .map(AllBoardListResponseDto::from)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private Board findUserBoard(Long boardId, Long userId) {

--- a/src/main/java/demo/userboard/service/BoardServiceImpl.java
+++ b/src/main/java/demo/userboard/service/BoardServiceImpl.java
@@ -7,6 +7,8 @@ import demo.userboard.dto.request.BoardUpdateRequestDto;
 import demo.userboard.dto.request.PostRequestDto;
 import demo.userboard.dto.response.AllBoardListResponseDto;
 import demo.userboard.dto.response.BoardDetailViewResponseDto;
+import demo.userboard.dto.response.PageInfoResponseDto;
+import demo.userboard.dto.response.PagingResponseDto;
 import demo.userboard.global.common.response.CustomErrorCode;
 import demo.userboard.global.core.exception.CustomException;
 import demo.userboard.repository.BoardRepository;
@@ -79,12 +81,18 @@ public class BoardServiceImpl implements BoardService {
     }
 
     @Override
-    public List<AllBoardListResponseDto> findAllBoard(int page, int size) {
+    public PageInfoResponseDto<AllBoardListResponseDto> findAllBoard(int page, int size) {
         List<Board> boardList = boardRepository.findAll(page, size);
-        return boardList
+        List<AllBoardListResponseDto> list = boardList
                 .stream()
                 .map(AllBoardListResponseDto::from)
                 .toList();
+
+        Long totalBoard = boardRepository.countAllBoards();
+        int numberOfElements = list.size();
+        boolean hasNext = page * size < totalBoard;
+        PagingResponseDto pagingResponseDto = new PagingResponseDto(page, size, hasNext, numberOfElements);
+        return new PageInfoResponseDto<>(list, pagingResponseDto);
     }
 
     private Board findUserBoard(Long boardId, Long userId) {

--- a/src/main/java/demo/userboard/service/BoardServiceImpl.java
+++ b/src/main/java/demo/userboard/service/BoardServiceImpl.java
@@ -79,8 +79,8 @@ public class BoardServiceImpl implements BoardService {
     }
 
     @Override
-    public List<AllBoardListResponseDto> findAllBoard() {
-        List<Board> boardList = boardRepository.findAll();
+    public List<AllBoardListResponseDto> findAllBoard(int page, int size) {
+        List<Board> boardList = boardRepository.findAll(page, size);
         return boardList
                 .stream()
                 .map(AllBoardListResponseDto::from)


### PR DESCRIPTION
## 작업 내용 (Content)

- AllBoardListResponseDto 생성(게시물 id, 게시물 title, 게시물 작성자 nickname)
- 레포지토리 클래스에 전체게시물 조회 메서드 구현
- 서비스 클래스에 응답값에 맞는 전체게시물리스트 생성 메서드 구현 
- 컨트롤러 클래스에 전체게시물 조회 메서드 구현

## 참고 링크 (Links)

- https://velog.io/@cieroyou/Stream%EC%9D%84-List%EB%A1%9C-%EB%B3%80%ED%99%98%ED%95%98%EB%8A%94-%EB%8B%A4%EC%96%91%ED%95%9C-%EB%B0%A9%EB%B2%95%EA%B3%BC-%EC%B0%A8%EC%9D%B4Collectors.toList-vs-Stream.toList

## 기타 사항 (Etc)

- 서비스 클래스에서 전체 게시물을 응답DTO에 맞게 맵핑하는데 성공했으나 오류가 나서 고민하던 와중에 리스트로 변환해야하는 문제를 발견하고 변환하는 과정에서 .collect(Collectors.toList())를 사용했는데, 참고링크를 통해 .toList()가 권고된다 하여 수정하게됐습니다. https://github.com/PNoahKR/user-board/commit/a2771e091dd264d28292013c81711cfca8bc904d

## 희망 리뷰 완료 일 (Expected due date)

- 2024-05-17 금
